### PR TITLE
Adjustments to token reponse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -395,3 +395,7 @@ HelseId.Data.Configuration.Tests/appsettings.local.json
 
 *helseid_*_log*
 .idea/*
+
+dotnet/.idea/.idea.HelseID.Packages/.idea/
+
+HelseId.Library/.idea/

--- a/HelseId.Library.ClientCredentials.Tests/HelseIdClientCredentialsFlowTests.cs
+++ b/HelseId.Library.ClientCredentials.Tests/HelseIdClientCredentialsFlowTests.cs
@@ -260,6 +260,7 @@ public class HelseIdClientCredentialsFlowTests : IDisposable
         tokenResponse.Should().BeOfType<AccessTokenResponse>();
         var accessTokenResponse = (AccessTokenResponse)tokenResponse;
         accessTokenResponse.AccessToken.Should().Be("access token from endpoint");
+        accessTokenResponse.RawResponse.Should().Be("{\"access_token\":\"access token from endpoint\",\"expires_in\":60}");
     }
     
     [Test]

--- a/HelseId.Library.ClientCredentials/HelseIdClientCredentialsFlow.cs
+++ b/HelseId.Library.ClientCredentials/HelseIdClientCredentialsFlow.cs
@@ -123,6 +123,7 @@ internal sealed class HelseIdClientCredentialsFlow : IHelseIdClientCredentialsFl
                     var accessTokenResponse = await response.Content.ReadFromJsonAsync<AccessTokenResponse>();
                     if (accessTokenResponse != null)
                     {
+                        accessTokenResponse.RawResponse = await response.Content.ReadAsStringAsync();
                         return accessTokenResponse;
                     }
                 }

--- a/HelseId.Library.ClientCredentials/HelseIdClientCredentialsFlow.cs
+++ b/HelseId.Library.ClientCredentials/HelseIdClientCredentialsFlow.cs
@@ -1,4 +1,5 @@
-﻿using HelseId.Library.Exceptions;
+﻿using HelseId.Library.ClientCredentials.Models;
+using HelseId.Library.Exceptions;
 
 namespace HelseId.Library.ClientCredentials;
 

--- a/HelseId.Library.ClientCredentials/Models/DPoPResponse.cs
+++ b/HelseId.Library.ClientCredentials/Models/DPoPResponse.cs
@@ -1,0 +1,6 @@
+﻿namespace HelseId.Library.ClientCredentials.Models;
+
+internal sealed class DPoPNonceResponse : TokenResponse
+{
+    public string? DPoPNonce { get; init; }
+}

--- a/HelseId.Library/Models/TokenResponse.cs
+++ b/HelseId.Library/Models/TokenResponse.cs
@@ -8,15 +8,10 @@ public class AccessTokenResponse : TokenResponse
 {
 
     [JsonPropertyName(JsonProperties.AccessToken)]
-    public string? AccessToken { get; init; }
+    public required string AccessToken { get; init; }
 
     [JsonPropertyName(JsonProperties.ExpiresIn)]
-    public int ExpiresIn { get; init; }
-}
-
-public class DPoPNonceResponse : TokenResponse
-{
-    public string? DPoPNonce { get; init; }
+    public required int ExpiresIn { get; init; }
 }
 
 public class TokenErrorResponse : TokenResponse

--- a/HelseId.Library/Models/TokenResponse.cs
+++ b/HelseId.Library/Models/TokenResponse.cs
@@ -2,6 +2,7 @@
 
 public abstract class TokenResponse
 {
+    public string RawResponse { get; set; } = "";
 }
 
 public class AccessTokenResponse : TokenResponse
@@ -21,6 +22,4 @@ public class TokenErrorResponse : TokenResponse
 
     [JsonPropertyName("error_description")]
     public string ErrorDescription { get; set; } = "";
-
-    public string RawResponse { get; set; } = "";
 }


### PR DESCRIPTION
* Make `AccessToken` property in `AccessTokenResponse` not nullable
* Always include `RawResponse` in `TokenResponse`
* Move DPoPNonceResponse to HelseID.ClientCredentials library and mark it as internal