### PR TITLE
Makes dpop proof creator use a type safe http method instead of string

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>0.9.2</Version>
+    <Version>0.9.3</Version>
   </PropertyGroup>
   <PropertyGroup>
     <Authors>Norsk Helsenett SF</Authors>

--- a/HelseID.ClientCredentials.TestApplication/Program.cs
+++ b/HelseID.ClientCredentials.TestApplication/Program.cs
@@ -82,7 +82,7 @@ public class TestService : IHostedService
         // Create a DPoP proof for an API request
         // This can be automated, see our documentation for more examples
         var dpopProof = await _dPoPProofCreator.CreateDPoPProofForApiRequest(
-            "POST", 
+            HttpMethod.Post, 
             "https://api.example.com/api-endpoint", 
             accessTokenResponse);
 

--- a/HelseId.Library.ClientCredentials.Tests/Services/HelseIdDPoPDelegatingHandlerTests.cs
+++ b/HelseId.Library.ClientCredentials.Tests/Services/HelseIdDPoPDelegatingHandlerTests.cs
@@ -34,6 +34,6 @@ public class HelseIdDPoPDelegatingHandlerTests
         clientCredentialsFlowMock.Scope.Should().Be("scope");
         dpopProofCreatorMock.AccessToken.Should().Be("access token");
         dpopProofCreatorMock.Url.Should().StartWith("https://helseid.no");
-        dpopProofCreatorMock.HttpMethod.Should().Be("GET");
+        dpopProofCreatorMock.HttpMethod.Should().Be(HttpMethod.Get);
     }
 }

--- a/HelseId.Library.ClientCredentials.Tests/Services/TokenRequests/ClientCredentialsTokenRequestBuilderTests.cs
+++ b/HelseId.Library.ClientCredentials.Tests/Services/TokenRequests/ClientCredentialsTokenRequestBuilderTests.cs
@@ -55,7 +55,7 @@ public class ClientCredentialsTokenRequestBuilderTests : TokenRequestBuilderTest
             _clientCredentialsTokenRequestParameters);
 
         DpoPProofCreatorMock.Url.Should().Be(HelseIdEndpointsDiscovererMock.TokenEndpoint);
-        DpoPProofCreatorMock.HttpMethod.Should().Be("POST");
+        DpoPProofCreatorMock.HttpMethod.Should().Be(HttpMethod.Post);
         DpoPProofCreatorMock.DPoPNonce.Should().BeNull();
         DpoPProofCreatorMock.AccessToken.Should().BeNull();
     }

--- a/HelseId.Library.ClientCredentials/Services/HelseIdDPoPDelegatingHandler.cs
+++ b/HelseId.Library.ClientCredentials/Services/HelseIdDPoPDelegatingHandler.cs
@@ -30,7 +30,7 @@ internal class HelseIdDPoPDelegatingHandler : DelegatingHandler
         if (tokenResponse.IsSuccessful(out var accessTokenResponse))
         {
             var dpopProof = await _idPoPProofCreator.CreateDPoPProofForApiRequest(
-                request.Method.ToString(),
+                request.Method,
                 request.RequestUri.ToString(),
                 accessTokenResponse);
 

--- a/HelseId.Library.Mocks/DPoPProofCreatorMock.cs
+++ b/HelseId.Library.Mocks/DPoPProofCreatorMock.cs
@@ -3,7 +3,7 @@ namespace HelseId.Library.Mocks;
 public class DPoPProofCreatorMock : IDPoPProofCreatorForApiRequests
 {
     public string? Url { get; private set; }
-    public string? HttpMethod { get; private set; }
+    public HttpMethod? HttpMethod { get; private set; }
     public string? AccessToken { get; private set; }
 
     private readonly string _dPoPProof;
@@ -13,7 +13,7 @@ public class DPoPProofCreatorMock : IDPoPProofCreatorForApiRequests
         _dPoPProof = dPoPProof;
     }
     
-    public Task<string> CreateDPoPProofForApiRequest(string httpMethod, string url, string accessToken)
+    public Task<string> CreateDPoPProofForApiRequest(HttpMethod httpMethod, string url, string accessToken)
     {
         Url = url;
         HttpMethod = httpMethod;
@@ -21,7 +21,7 @@ public class DPoPProofCreatorMock : IDPoPProofCreatorForApiRequests
         return Task.FromResult(_dPoPProof);
     }
 
-    public Task<string> CreateDPoPProofForApiRequest(string httpMethod, string url, AccessTokenResponse accessTokenResponse)
+    public Task<string> CreateDPoPProofForApiRequest(HttpMethod httpMethod, string url, AccessTokenResponse accessTokenResponse)
     {
         Url = url;
         HttpMethod = httpMethod;

--- a/HelseId.Library.Selvbetjening.Tests/ClientSecretEndpointTests.cs
+++ b/HelseId.Library.Selvbetjening.Tests/ClientSecretEndpointTests.cs
@@ -92,7 +92,7 @@ public class ClientSecretEndpointTests
         await _clientSecretEndpoint.GetClientSecretRequest(PublicKey);
 
         _dpoPProofCreatorMock.Url.Should().Be(UpdateClientSecretEndpoint);
-        _dpoPProofCreatorMock.HttpMethod.Should().Be("POST");
+        _dpoPProofCreatorMock.HttpMethod.Should().Be(HttpMethod.Post);
         _dpoPProofCreatorMock.AccessToken.Should().Be(AccessToken);
     }
 }

--- a/HelseId.Library.Selvbetjening/ClientSecretEndpoint.cs
+++ b/HelseId.Library.Selvbetjening/ClientSecretEndpoint.cs
@@ -35,7 +35,7 @@ public class ClientSecretEndpoint : IClientSecretEndpoint
 
         var accessTokenResponse = (AccessTokenResponse)tokenResponse;
         var dPopProof = await _idPoPProofCreator.CreateDPoPProofForApiRequest(
-            "POST",
+            HttpMethod.Post, 
             _selvbetjeningConfiguration.UpdateClientSecretEndpoint, 
             accessTokenResponse);
     

--- a/HelseId.Library.Tests/Services/JwtTokens/DPoPProofCreatorTests.cs
+++ b/HelseId.Library.Tests/Services/JwtTokens/DPoPProofCreatorTests.cs
@@ -8,7 +8,6 @@ namespace HelseId.Library.Tests.Services.JwtTokens;
 public class DPoPProofCreatorTests : ConfigurationTests
 {
     private const string Url = "https://helseid-sts.nhn.no/connect/token";
-    private const string HttpMethod = "POST";
     private FakeTimeProvider _fakeTimeProvider = null!;    
     private DPoPProofCreator _dPoPProofCreator = null!;
     
@@ -24,7 +23,7 @@ public class DPoPProofCreatorTests : ConfigurationTests
     [Test]
     public async Task CreateDPoPProofForTokenRequest_sets_standard_dpop_proof()
     {
-        var dPoPProof = await _dPoPProofCreator.CreateDPoPProofForTokenRequest(Url, HttpMethod);
+        var dPoPProof = await _dPoPProofCreator.CreateDPoPProofForTokenRequest(HttpMethod.Post, Url);
 
         dPoPProof.Should().NotBeNullOrEmpty();
 
@@ -43,7 +42,7 @@ public class DPoPProofCreatorTests : ConfigurationTests
     [Test]
     public async Task CreateDPoPProofForTokenRequest_sets_dpop_proof_with_nonce()
     {
-        var dPoPProof = await _dPoPProofCreator.CreateDPoPProofForTokenRequest(Url, HttpMethod, dPoPNonce: "2bc376b6-68ac-46d8-837e-3b5e02530b62");
+        var dPoPProof = await _dPoPProofCreator.CreateDPoPProofForTokenRequest(HttpMethod.Post, Url, dPoPNonce: "2bc376b6-68ac-46d8-837e-3b5e02530b62");
 
         var token = GetJsonWebToken(dPoPProof);
 
@@ -53,7 +52,7 @@ public class DPoPProofCreatorTests : ConfigurationTests
     [Test]
     public async Task CreateDPoPProofForApiCall_sets_dpop_proof_with_access_token_hash()
     {
-        var dPoPProof = await _dPoPProofCreator.CreateDPoPProofForApiRequest(HttpMethod, Url, accessToken: "eyJhbGciOiJSUzI1NiIsImtpZCI6Ijc4NjY3RjkwREMxMUJGMDRCRDk0NjdEMUY5MTIwQzRBNDM0MEI0Q0YiLCJ4NXQiOiJlR1pfa053UnZ3UzlsR2ZSLVJJTVNrTkF0TTgiLCJ0eXAiOiJhdCtqd3QifQ.eyJpc3MiOiJodHRwczovL2hlbHNlaWQtc3RzLnRlc3QubmhuLm5vIiwibmJmIjoxNzM1OTkzODkzLCJpYXQiOjE3MzU5OTM4OTMsImV4cCI6MTczNTk5NDQ5MywiYXVkIjoibmhuOnRlc3QtcHVibGljLXNhbXBsZWNvZGUiLCJjbmYiOnsiamt0IjoiYW9lenZJZTMyUmRGcFRQNEZJeHdCWWI2VkdYMGRwM2Vjdm9WakZrZFhRayJ9LCJzY29wZSI6WyJvcGVuaWQiLCJwcm9maWxlIiwibmhuOnRlc3QtcHVibGljLXNhbXBsZWNvZGUvYXV0aG9yaXphdGlvbi1jb2RlIiwiaGVsc2VpZDovL3Njb3Blcy9pZGVudGl0eS9waWQiLCJoZWxzZWlkOi8vc2NvcGVzL2lkZW50aXR5L3BpZF9wc2V1ZG9ueW0iLCJoZWxzZWlkOi8vc2NvcGVzL2lkZW50aXR5L2Fzc3VyYW5jZV9sZXZlbCIsImhlbHNlaWQ6Ly9zY29wZXMvaHByL2hwcl9udW1iZXIiLCJoZWxzZWlkOi8vc2NvcGVzL2lkZW50aXR5L25ldHdvcmsiLCJoZWxzZWlkOi8vc2NvcGVzL2lkZW50aXR5L3NlY3VyaXR5X2xldmVsIiwib2ZmbGluZV9hY2Nlc3MiXSwiYW1yIjpbInB3ZCJdLCJjbGllbnRfaWQiOiJoZWxzZWlkLXNhbXBsZS1hcGktYWNjZXNzIiwiY2xpZW50X2FtciI6InByaXZhdGVfa2V5X2p3dCIsImhlbHNlaWQ6Ly9jbGFpbXMvY2xpZW50L2NsYWltcy9vcmducl9wYXJlbnQiOiI5OTk5Nzc3NzQiLCJzdWIiOiJjNFNyaEtPYnBvRmJYXHUwMDJCdm9aVUhsRzlSQ0tkSGFDWEFTdXhsdGtDUkFRVW89IiwiYXV0aF90aW1lIjoxNzM1OTkzODkyLCJpZHAiOiJ0ZXN0aWRwLW9pZGMiLCJoZWxzZWlkOi8vY2xhaW1zL2lkZW50aXR5L3BpZCI6IjE1ODQ5MTk3MzUyIiwiaGVsc2VpZDovL2NsYWltcy9pZGVudGl0eS9zZWN1cml0eV9sZXZlbCI6IjQiLCJoZWxzZWlkOi8vY2xhaW1zL2lkZW50aXR5L2Fzc3VyYW5jZV9sZXZlbCI6ImhpZ2giLCJoZWxzZWlkOi8vY2xhaW1zL2hwci9ocHJfbnVtYmVyIjoiNTY1NTUwODQ2IiwibmFtZSI6IkxJVlNUUkVUVCBCRVZFUiIsImhlbHNlaWQ6Ly9jbGFpbXMvaWRlbnRpdHkvbmV0d29yayI6ImludGVybmV0dCIsImhlbHNlaWQ6Ly9jbGFpbXMvY2xpZW50L2NsaWVudF9uYW1lIjoiaGVsc2VpZC1zYW1wbGUtYXBpLWFjY2VzcyIsImhlbHNlaWQ6Ly9jbGFpbXMvY2xpZW50L2NsaWVudF90ZW5hbmN5Ijoic2luZ2xlLXRlbmFudCIsInNpZCI6IkNDMjQ2MkMyMzhDRjk0NDMzNTFBMzIwMDhFRTlGMTVDIiwianRpIjoiRkY4RkQ2RDMwMzUwNDkwRkExNDcwMjgxMUI3NTE5OEYifQ.f2n0rzuDAu1B4v9tGkKBTryzdBc_-nuaZxE-N0pr0cxxa6Rx8vH7WcnGd63Ie989YqhLcKi5fY_9Meym-ipJbJzxw-vOnn9D7C-oyeeqZcH8aRWzGpmvPmaeIsuc0Kj5Jxnf6QnBDUteHhb7qP7Jec4S9goOUm_hQvnA_sgAPYMK14Pou5E-av0Pc-CVFzxlhhexCApO07vQ5FsfDo17ZIQSmMIz-m3bSDthKreWEnap2Jg_ZRmoSnbbfNCXST6Fm11oND-hQeo9EHhgocZoAme8xtFUPKESAZVWbsOqkr7UBR5Nh8Kiaid_ZGUYmoyHltjPa5H_Cg1qmjctfWvdud8IIcwAlRpKLdYV5JcJxSJQKGL7vRz1bzEtZbimMS9_PBobwOSpD96HUyhYG7tqhqddxKK3-vzKx0T7MP-uYjxMA-I5DZKGjbrTxdgEip7DkjbZZ3cs-mUc7KbFapt6ijdo9CbVyILPcr7BrKBaNRb9YJD49epTLbchmSqHIQBb");
+        var dPoPProof = await _dPoPProofCreator.CreateDPoPProofForApiRequest(HttpMethod.Post, Url, accessToken: "eyJhbGciOiJSUzI1NiIsImtpZCI6Ijc4NjY3RjkwREMxMUJGMDRCRDk0NjdEMUY5MTIwQzRBNDM0MEI0Q0YiLCJ4NXQiOiJlR1pfa053UnZ3UzlsR2ZSLVJJTVNrTkF0TTgiLCJ0eXAiOiJhdCtqd3QifQ.eyJpc3MiOiJodHRwczovL2hlbHNlaWQtc3RzLnRlc3QubmhuLm5vIiwibmJmIjoxNzM1OTkzODkzLCJpYXQiOjE3MzU5OTM4OTMsImV4cCI6MTczNTk5NDQ5MywiYXVkIjoibmhuOnRlc3QtcHVibGljLXNhbXBsZWNvZGUiLCJjbmYiOnsiamt0IjoiYW9lenZJZTMyUmRGcFRQNEZJeHdCWWI2VkdYMGRwM2Vjdm9WakZrZFhRayJ9LCJzY29wZSI6WyJvcGVuaWQiLCJwcm9maWxlIiwibmhuOnRlc3QtcHVibGljLXNhbXBsZWNvZGUvYXV0aG9yaXphdGlvbi1jb2RlIiwiaGVsc2VpZDovL3Njb3Blcy9pZGVudGl0eS9waWQiLCJoZWxzZWlkOi8vc2NvcGVzL2lkZW50aXR5L3BpZF9wc2V1ZG9ueW0iLCJoZWxzZWlkOi8vc2NvcGVzL2lkZW50aXR5L2Fzc3VyYW5jZV9sZXZlbCIsImhlbHNlaWQ6Ly9zY29wZXMvaHByL2hwcl9udW1iZXIiLCJoZWxzZWlkOi8vc2NvcGVzL2lkZW50aXR5L25ldHdvcmsiLCJoZWxzZWlkOi8vc2NvcGVzL2lkZW50aXR5L3NlY3VyaXR5X2xldmVsIiwib2ZmbGluZV9hY2Nlc3MiXSwiYW1yIjpbInB3ZCJdLCJjbGllbnRfaWQiOiJoZWxzZWlkLXNhbXBsZS1hcGktYWNjZXNzIiwiY2xpZW50X2FtciI6InByaXZhdGVfa2V5X2p3dCIsImhlbHNlaWQ6Ly9jbGFpbXMvY2xpZW50L2NsYWltcy9vcmducl9wYXJlbnQiOiI5OTk5Nzc3NzQiLCJzdWIiOiJjNFNyaEtPYnBvRmJYXHUwMDJCdm9aVUhsRzlSQ0tkSGFDWEFTdXhsdGtDUkFRVW89IiwiYXV0aF90aW1lIjoxNzM1OTkzODkyLCJpZHAiOiJ0ZXN0aWRwLW9pZGMiLCJoZWxzZWlkOi8vY2xhaW1zL2lkZW50aXR5L3BpZCI6IjE1ODQ5MTk3MzUyIiwiaGVsc2VpZDovL2NsYWltcy9pZGVudGl0eS9zZWN1cml0eV9sZXZlbCI6IjQiLCJoZWxzZWlkOi8vY2xhaW1zL2lkZW50aXR5L2Fzc3VyYW5jZV9sZXZlbCI6ImhpZ2giLCJoZWxzZWlkOi8vY2xhaW1zL2hwci9ocHJfbnVtYmVyIjoiNTY1NTUwODQ2IiwibmFtZSI6IkxJVlNUUkVUVCBCRVZFUiIsImhlbHNlaWQ6Ly9jbGFpbXMvaWRlbnRpdHkvbmV0d29yayI6ImludGVybmV0dCIsImhlbHNlaWQ6Ly9jbGFpbXMvY2xpZW50L2NsaWVudF9uYW1lIjoiaGVsc2VpZC1zYW1wbGUtYXBpLWFjY2VzcyIsImhlbHNlaWQ6Ly9jbGFpbXMvY2xpZW50L2NsaWVudF90ZW5hbmN5Ijoic2luZ2xlLXRlbmFudCIsInNpZCI6IkNDMjQ2MkMyMzhDRjk0NDMzNTFBMzIwMDhFRTlGMTVDIiwianRpIjoiRkY4RkQ2RDMwMzUwNDkwRkExNDcwMjgxMUI3NTE5OEYifQ.f2n0rzuDAu1B4v9tGkKBTryzdBc_-nuaZxE-N0pr0cxxa6Rx8vH7WcnGd63Ie989YqhLcKi5fY_9Meym-ipJbJzxw-vOnn9D7C-oyeeqZcH8aRWzGpmvPmaeIsuc0Kj5Jxnf6QnBDUteHhb7qP7Jec4S9goOUm_hQvnA_sgAPYMK14Pou5E-av0Pc-CVFzxlhhexCApO07vQ5FsfDo17ZIQSmMIz-m3bSDthKreWEnap2Jg_ZRmoSnbbfNCXST6Fm11oND-hQeo9EHhgocZoAme8xtFUPKESAZVWbsOqkr7UBR5Nh8Kiaid_ZGUYmoyHltjPa5H_Cg1qmjctfWvdud8IIcwAlRpKLdYV5JcJxSJQKGL7vRz1bzEtZbimMS9_PBobwOSpD96HUyhYG7tqhqddxKK3-vzKx0T7MP-uYjxMA-I5DZKGjbrTxdgEip7DkjbZZ3cs-mUc7KbFapt6ijdo9CbVyILPcr7BrKBaNRb9YJD49epTLbchmSqHIQBb");
 
         var token = GetJsonWebToken(dPoPProof);
 
@@ -65,7 +64,7 @@ public class DPoPProofCreatorTests : ConfigurationTests
     {
         _dPoPProofCreator = new DPoPProofCreator(CredentialWithEcKey, _fakeTimeProvider);
         
-        var dPoPProof = await _dPoPProofCreator.CreateDPoPProofForTokenRequest(Url, HttpMethod);
+        var dPoPProof = await _dPoPProofCreator.CreateDPoPProofForTokenRequest(HttpMethod.Post, Url);
 
         var token = GetJsonWebToken(dPoPProof);
 
@@ -78,7 +77,7 @@ public class DPoPProofCreatorTests : ConfigurationTests
     {
         _dPoPProofCreator = new DPoPProofCreator(CredentialWithInvalidKey, _fakeTimeProvider);
 
-        Func<Task> createDPoPProof = async () => await _dPoPProofCreator.CreateDPoPProofForTokenRequest(Url, HttpMethod);
+        Func<Task> createDPoPProof = async () => await _dPoPProofCreator.CreateDPoPProofForTokenRequest(HttpMethod.Post, Url);
         
         createDPoPProof.Should().ThrowAsync<InvalidKeyTypeForDPoPProofException>().Result.WithMessage("An invalid key was set for the DPoP proof.");
     }
@@ -88,7 +87,7 @@ public class DPoPProofCreatorTests : ConfigurationTests
     {
         _dPoPProofCreator = new DPoPProofCreator(GetX509CredentialReference(), _fakeTimeProvider);
         
-        var dPoPProof = await _dPoPProofCreator.CreateDPoPProofForTokenRequest(Url, HttpMethod);
+        var dPoPProof = await _dPoPProofCreator.CreateDPoPProofForTokenRequest(HttpMethod.Post, Url);
 
         var token = GetJsonWebToken(dPoPProof);
 
@@ -102,7 +101,7 @@ public class DPoPProofCreatorTests : ConfigurationTests
     {
         _dPoPProofCreator = new DPoPProofCreator(CredentialWithEcKey, _fakeTimeProvider);
         
-        Func<Task> createProofWithInvalidUrl = async () => await _dPoPProofCreator.CreateDPoPProofForTokenRequest("https://server.com/?query=a&string=b", HttpMethod);
+        Func<Task> createProofWithInvalidUrl = async () => await _dPoPProofCreator.CreateDPoPProofForTokenRequest(HttpMethod.Post,"https://server.com/?query=a&string=b");
 
         await createProofWithInvalidUrl.Should().ThrowAsync<HelseIdException>();
     }
@@ -113,6 +112,6 @@ public class DPoPProofCreatorTests : ConfigurationTests
         JsonWebTokenHandler handler = new JsonWebTokenHandler();
         var token = handler.ReadToken(dPoPProof) as JsonWebToken;
         token.Should().NotBeNull();
-        return token!;
+        return token;
     }
 }

--- a/HelseId.Library.Tests/Services/TokenRequests/TokenRequestBuilderTests.cs
+++ b/HelseId.Library.Tests/Services/TokenRequests/TokenRequestBuilderTests.cs
@@ -27,7 +27,7 @@ public abstract class TokenRequestBuilderTests : ConfigurationTests
 public class DPoPProofCreatorForTokenRequestMock : IDPoPProofCreator
 {
     public string? Url { get; private set; }
-    public string? HttpMethod { get; private set; }
+    public HttpMethod? HttpMethod { get; private set; }
     public string? DPoPNonce { get; private set; }
     public string? AccessToken { get; private set; }
 
@@ -38,7 +38,7 @@ public class DPoPProofCreatorForTokenRequestMock : IDPoPProofCreator
         _dPoPProof = dPoPProof;
     }
     
-    public Task<string> CreateDPoPProofForTokenRequest(string url, string httpMethod, string? dPoPNonce = null)
+    public Task<string> CreateDPoPProofForTokenRequest(HttpMethod httpMethod, string url, string? dPoPNonce = null)
     {
         Url = url;
         HttpMethod = httpMethod;

--- a/HelseId.Library/Interfaces/JwtTokens/IDPoPProofCreator.cs
+++ b/HelseId.Library/Interfaces/JwtTokens/IDPoPProofCreator.cs
@@ -5,13 +5,13 @@ internal interface IDPoPProofCreator
     /// <summary>
     /// Creates a DPoP proof using the registered key pair with the given parameters.
     /// </summary>
-    /// <param name="url">The url for the request</param>
     /// <param name="httpMethod">The HttpMethod for the request</param>
+    /// <param name="url">The url for the request</param>
     /// <param name="dPoPNonce">The server supplied nonce value</param>
     /// <returns></returns>
     Task<string> CreateDPoPProofForTokenRequest(
+        HttpMethod httpMethod,
         string url,
-        string httpMethod,
         string? dPoPNonce = null);
 }
 

--- a/HelseId.Library/Interfaces/JwtTokens/IDPoPProofCreatorForApiRequests.cs
+++ b/HelseId.Library/Interfaces/JwtTokens/IDPoPProofCreatorForApiRequests.cs
@@ -10,7 +10,7 @@ public interface IDPoPProofCreatorForApiRequests
     /// <param name="accessToken">The Access Token the DPoP proof should be bound to</param>
     /// <returns></returns>
     Task<string> CreateDPoPProofForApiRequest(
-        string httpMethod,
+        HttpMethod httpMethod,
         string url,
         string accessToken);
     
@@ -22,7 +22,7 @@ public interface IDPoPProofCreatorForApiRequests
     /// <param name="accessTokenResponse">The Access Token Response the DPoP proof should be bound to</param>
     /// <returns></returns>
     Task<string> CreateDPoPProofForApiRequest(
-        string httpMethod,
+        HttpMethod httpMethod,
         string url,
         AccessTokenResponse accessTokenResponse);
 }

--- a/HelseId.Library/Services/JwtTokens/DPoPProofCreator.cs
+++ b/HelseId.Library/Services/JwtTokens/DPoPProofCreator.cs
@@ -11,12 +11,12 @@ public class DPoPProofCreator : IDPoPProofCreator, IDPoPProofCreatorForApiReques
         _timeProvider = timeProvider;
     }
 
-    public Task<string> CreateDPoPProofForTokenRequest(string url, string httpMethod, string? dPoPNonce = null)
+    public Task<string> CreateDPoPProofForTokenRequest(HttpMethod httpMethod, string url, string? dPoPNonce = null)
     {
         return CreateDPoPProofInternal(url, httpMethod, dPoPNonce);
     }
 
-    public Task<string> CreateDPoPProofForApiRequest(string httpMethod, string url, string accessToken)
+    public Task<string> CreateDPoPProofForApiRequest(HttpMethod httpMethod, string url, string accessToken)
     {
         return CreateDPoPProofInternal(url,
             httpMethod,
@@ -24,7 +24,7 @@ public class DPoPProofCreator : IDPoPProofCreator, IDPoPProofCreatorForApiReques
             accessToken);
     }
 
-    public Task<string> CreateDPoPProofForApiRequest(string httpMethod, string url, AccessTokenResponse accessTokenResponse)
+    public Task<string> CreateDPoPProofForApiRequest(HttpMethod httpMethod, string url, AccessTokenResponse accessTokenResponse)
     {
         return CreateDPoPProofInternal(url,
             httpMethod,
@@ -34,7 +34,7 @@ public class DPoPProofCreator : IDPoPProofCreator, IDPoPProofCreatorForApiReques
 
     private async Task<string> CreateDPoPProofInternal(
         string url,
-        string httpMethod,
+        HttpMethod httpMethod,
         string? dPoPNonce = null,
         string? accessToken = null)
     {
@@ -61,7 +61,7 @@ public class DPoPProofCreator : IDPoPProofCreator, IDPoPProofCreatorForApiReques
         return tokenHandler.CreateToken(securityTokenDescriptor);
     }
 
-    private Dictionary<string, object> SetClaims(string url, string httpMethod, string? dPoPNonce, string? accessToken)
+    private Dictionary<string, object> SetClaims(string url, HttpMethod httpMethod, string? dPoPNonce, string? accessToken)
     {
         var claims = SetGeneralClaims(url, httpMethod);
 
@@ -72,12 +72,12 @@ public class DPoPProofCreator : IDPoPProofCreator, IDPoPProofCreatorForApiReques
         return claims;
     }
 
-    private Dictionary<string, object> SetGeneralClaims(string url, string httpMethod)
+    private Dictionary<string, object> SetGeneralClaims(string url, HttpMethod httpMethod)
     {
         return new Dictionary<string, object>()
         {
             [JwtRegisteredClaimNames.Jti] = Guid.NewGuid().ToString(),
-            ["htm"] = httpMethod,
+            ["htm"] = httpMethod.Method,
             ["htu"] = url,
             ["iat"] = _timeProvider.GetUtcNow().ToUnixTimeSeconds(),
         };

--- a/HelseId.Library/Services/TokenRequests/TokenRequestBuilder.cs
+++ b/HelseId.Library/Services/TokenRequests/TokenRequestBuilder.cs
@@ -29,6 +29,6 @@ public abstract class TokenRequestBuilder
 
     protected Task<string> CreateDPoPProof(string tokenEndpoint, string? dPoPNonce = null)
     {
-        return _dPoPProofCreator.CreateDPoPProofForTokenRequest(tokenEndpoint, "POST", dPoPNonce: dPoPNonce);
+        return _dPoPProofCreator.CreateDPoPProofForTokenRequest(HttpMethod.Post, tokenEndpoint, dPoPNonce: dPoPNonce);
     }
 }


### PR DESCRIPTION
Modifies the DPoP proof creators to use the `HttpMethod` type instead of a string parameter.
Updates the version of the library to v0.9.3